### PR TITLE
[linux][browser-wasm] Collect everything next to `mono-aot-cross`

### DIFF
--- a/src/monostump/AssetRepository.cs
+++ b/src/monostump/AssetRepository.cs
@@ -19,6 +19,7 @@ public class AssetRepository
         ToolingAssembly,
         ToolingBinary,
         ToolingUnixyBinTree,
+        ToolingDirectory,
         GeneratedProject,
         GeneratedOther,
     }
@@ -30,6 +31,7 @@ public class AssetRepository
             AssetKind.ToolingAssembly => true,
             AssetKind.ToolingBinary => true,
             AssetKind.ToolingUnixyBinTree => true,
+            AssetKind.ToolingDirectory => true,
             _ => false,
         };
     }
@@ -484,6 +486,7 @@ public class AssetRepository
         const string devilIcon = "👿 ";
         const string notebookIcon = "📓 ";
         const string binaryToolIcon = "🔨 ";
+        const string toolboxIcon = "🧰 ";
         const string packageIcon = "📦 ";
         const string videocasetteIcon = "📼 ";
         foreach (var child in folder.Children)
@@ -506,6 +509,7 @@ public class AssetRepository
                     AssetKind.InputOther => notebookIcon,
                     AssetKind.ToolingAssembly => videocasetteIcon,
                     AssetKind.ToolingBinary => binaryToolIcon,
+                    AssetKind.ToolingDirectory => toolboxIcon,
                     AssetKind.ToolingUnixyBinTree => devilIcon,
                     AssetKind.GeneratedProject => gearIcon,
                     AssetKind.GeneratedOther => gearIcon,
@@ -558,6 +562,9 @@ public class AssetRepository
                             using var fileStream = new FileStream(asset.OriginalPath, FileMode.Open, FileAccess.Read);
                             fileStream.CopyTo(entryStream);
                         }
+                        break;
+                    case AssetKind.ToolingDirectory:
+                        AddFullDirectory(asset.OriginalPath, assetPath, "*", archive);
                         break;
                     case AssetKind.InputManagedAssemblyDirectory:
                         AddFullDirectory(asset.OriginalPath, assetPath, "*.dll", archive);

--- a/src/monostump/RuntimeAotCompilerScraper.cs
+++ b/src/monostump/RuntimeAotCompilerScraper.cs
@@ -186,7 +186,7 @@ public class RuntimeAotCompilerScraper : ITaskScraper, TaskModel.IBuilderCallbac
                     _logger.LogError("CompilerBinaryPath property has no directory or name: {CompilerBinaryPath}", property.Value);
                     throw new InvalidOperationException("CompilerBinaryPath property has no directory or name");
                 }
-                AssetRepository.AssetPath compilerDirAsset = _assets.GetOrAddToolingAsset(property.Value, AssetRepository.AssetKind.ToolingDirectory);
+                AssetRepository.AssetPath compilerDirAsset = _assets.GetOrAddToolingAsset(compilerDir, AssetRepository.AssetKind.ToolingDirectory);
                 builder.AddTaskProperty(new () { Name = property.Name, SpecialValue = () => Path.Join(_assets.GetAssetRelativePath(compilerDirAsset), compilerName) });
                 break;
             case WorkingDirectory:

--- a/src/monostump/RuntimeAotCompilerScraper.cs
+++ b/src/monostump/RuntimeAotCompilerScraper.cs
@@ -178,8 +178,16 @@ public class RuntimeAotCompilerScraper : ITaskScraper, TaskModel.IBuilderCallbac
                 builder.AddTaskProperty(new () { Name = property.Name, AssetValue = llvmPath });
                 break;
             case CompilerBinaryPath:
-                AssetRepository.AssetPath compilerPath = _assets.GetOrAddToolingAsset(property.Value, AssetRepository.AssetKind.ToolingBinary);
-                builder.AddTaskProperty(new () { Name = property.Name, AssetValue = compilerPath });
+                string compilerPath = property.Value;
+                string? compilerName = Path.GetFileName(compilerPath);
+                string? compilerDir = Path.GetDirectoryName(compilerPath);
+                if (string.IsNullOrEmpty(compilerName) || string.IsNullOrEmpty(compilerDir))
+                {
+                    _logger.LogError("CompilerBinaryPath property has no directory or name: {CompilerBinaryPath}", property.Value);
+                    throw new InvalidOperationException("CompilerBinaryPath property has no directory or name");
+                }
+                AssetRepository.AssetPath compilerDirAsset = _assets.GetOrAddToolingAsset(property.Value, AssetRepository.AssetKind.ToolingDirectory);
+                builder.AddTaskProperty(new () { Name = property.Name, SpecialValue = () => Path.Join(_assets.GetAssetRelativePath(compilerDirAsset), compilerName) });
                 break;
             case WorkingDirectory:
                 // FIXME: this is a hack that happens to work for Android


### PR DESCRIPTION
The compiler depends on .so files next to `mono-aot-cross` on Linux.

Fixes #1 